### PR TITLE
Use anonymous keyword arguments forwarding in Types

### DIFF
--- a/lib/ruby_vault/options/types.rb
+++ b/lib/ruby_vault/options/types.rb
@@ -6,8 +6,8 @@ require_relative 'types/flag'
 module RubyVault
   module Options
     module Types
-      def self.standard(name, value, **opts)
-        Standard.new(name, value, **opts)
+      def self.standard(name, value, **)
+        Standard.new(name, value, **)
       end
 
       def self.flag(name, value)


### PR DESCRIPTION
Fixes two pre-existing `Style/ArgumentsForwarding` RuboCop offences in `lib/ruby_vault/options/types.rb` by using anonymous keyword arguments forwarding (`**`).

This lint failure is currently blocking the `check` job on the GHA migration PR #131.